### PR TITLE
⚡ Bolt: Optimize text rendering allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - Unnecessary String Allocations in Render Loops
+**Learning:** Iterating over `text.chars()` and calling `.to_string()` for each character inside a rendering loop (e.g., for individual character effects) creates significant allocator pressure and overhead.
+**Action:** Use `text.char_indices()` and slice the original string (`&text[i..i+len]`) to pass `&str` slices to Skia/rendering functions. This avoids all heap allocations per character.

--- a/library/src/core/rendering/skia_renderer.rs
+++ b/library/src/core/rendering/skia_renderer.rs
@@ -372,15 +372,16 @@ impl SkiaRenderer {
             };
 
             // Text decomposition: measure each character
-            let mut char_data = Vec::new();
+            let mut char_data = Vec::with_capacity(text.len());
             let mut x_pos = 0.0f32;
 
-            for ch in text.chars() {
-                let ch_str = ch.to_string();
-                let (advance, _bounds) = font.measure_str(&ch_str, None);
+            for (i, ch) in text.char_indices() {
+                let len = ch.len_utf8();
+                let ch_str = &text[i..i + len];
+                let (advance, _bounds) = font.measure_str(ch_str, None);
 
                 // Store char data
-                char_data.push((ch, x_pos, advance));
+                char_data.push((ch_str, x_pos, advance));
                 x_pos += advance;
             }
 
@@ -600,7 +601,7 @@ impl SkiaRenderer {
             }
 
             // Render each character with its transform
-            for (i, (ch, base_x, _advance)) in char_data.iter().enumerate() {
+            for (i, (ch_str, base_x, _advance)) in char_data.iter().enumerate() {
                 let ch_transform = &char_transforms[i];
 
                 // Apply character transform
@@ -631,9 +632,8 @@ impl SkiaRenderer {
                 paint.set_anti_alias(true);
 
                 // Draw character
-                let ch_str = ch.to_string();
                 // Use baseline_offset for accurate positioning to match standard text rendering
-                canvas.draw_str(&ch_str, (*base_x, baseline_offset), &font, &paint);
+                canvas.draw_str(ch_str, (*base_x, baseline_offset), &font, &paint);
 
                 canvas.restore();
             }


### PR DESCRIPTION
*   💡 **What**: Replaced `char.to_string()` allocations with `&str` slicing in `SkiaRenderer::rasterize_ensemble_text`.
*   🎯 **Why**: The previous implementation allocated a new `String` on the heap for every single character during text rendering, creating significant allocator pressure and overhead in the render loop.
*   📊 **Impact**: Eliminates N heap allocations per text render call (where N is the number of characters), reducing CPU usage and memory churn.
*   🔬 **Measurement**: Verified with `cargo check` for lifetime correctness and logic verification script. Existing tests pass.

---
*PR created automatically by Jules for task [10426023289167795866](https://jules.google.com/task/10426023289167795866) started by @Liesegang*

## Summary by Sourcery

Optimize Skia text rendering by avoiding per-character string allocations and using pre-sized character metadata storage.

Enhancements:
- Reduce text rendering overhead by reusing string slices from the original text via char indices instead of allocating new Strings per character.
- Preallocate character metadata storage based on text length to minimize allocation during rasterization.

Documentation:
- Add an internal Bolt note documenting the rendering performance issue with per-character String allocations and the preferred string slicing approach.