### PR TITLE
Add Rust file-size ratchet check and integrate into quality gate

### DIFF
--- a/scripts/check-rust-file-size-ratchet.sh
+++ b/scripts/check-rust-file-size-ratchet.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_LINES=1000
+BASELINE_REF="${RUST_FILE_SIZE_BASE_REF:-}"
+SCAN_ROOT=""
+
+usage() {
+    echo "usage: $0 [--root DIRECTORY] [--baseline-ref GIT_REF] [--max-lines COUNT]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root) [[ $# -ge 2 ]] || { usage; exit 2; }; SCAN_ROOT="$2"; shift 2 ;;
+        --baseline-ref) [[ $# -ge 2 ]] || { usage; exit 2; }; BASELINE_REF="$2"; shift 2 ;;
+        --max-lines) [[ $# -ge 2 ]] || { usage; exit 2; }; MAX_LINES="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage; exit 2 ;;
+    esac
+done
+
+case "${MAX_LINES}" in
+    ''|*[!0-9]*) echo "Rust file line limit must be a positive integer: ${MAX_LINES}" >&2; exit 2 ;;
+esac
+if [[ "${MAX_LINES}" -eq 0 ]]; then
+    echo "Rust file line limit must be greater than zero" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SCAN_ROOT}" ]]; then
+    SCAN_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+elif [[ ! -d "${SCAN_ROOT}" ]]; then
+    echo "Rust file scan root is not a directory: ${SCAN_ROOT}" >&2
+    exit 2
+else
+    SCAN_ROOT="$(cd -- "${SCAN_ROOT}" && pwd)"
+fi
+
+if ! git -C "${SCAN_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Rust file size ratchet requires a Git worktree: ${SCAN_ROOT}" >&2
+    exit 2
+fi
+
+if [[ -z "${BASELINE_REF}" ]]; then
+    if git -C "${SCAN_ROOT}" rev-parse --verify --quiet 'origin/main^{commit}' >/dev/null; then
+        BASELINE_REF=origin/main
+    elif git -C "${SCAN_ROOT}" rev-parse --verify --quiet 'main^{commit}' >/dev/null; then
+        BASELINE_REF=main
+    else
+        echo "Rust file size baseline is required; pass --baseline-ref or set RUST_FILE_SIZE_BASE_REF" >&2
+        exit 2
+    fi
+fi
+if ! git -C "${SCAN_ROOT}" rev-parse --verify --quiet "${BASELINE_REF}^{commit}" >/dev/null; then
+    echo "Rust file size baseline is not a commit: ${BASELINE_REF}" >&2
+    exit 2
+fi
+if ! git -C "${SCAN_ROOT}" merge-base --is-ancestor "${BASELINE_REF}" HEAD; then
+    echo "Rust file size baseline must be an ancestor of HEAD: ${BASELINE_REF}" >&2
+    exit 2
+fi
+
+declare -A baseline_lines=()
+while IFS= read -r -d '' rust_file; do
+    [[ "${rust_file}" == *.rs ]] || continue
+    baseline_lines["${rust_file}"]="$(
+        git -C "${SCAN_ROOT}" show "${BASELINE_REF}:${rust_file}" |
+            awk 'END { print NR + 0 }'
+    )"
+done < <(git -C "${SCAN_ROOT}" ls-tree -r --name-only -z "${BASELINE_REF}")
+
+checked=0
+violations=0
+while IFS= read -r -d '' rust_file; do
+    absolute_path="${SCAN_ROOT}/${rust_file}"
+    [[ -f "${absolute_path}" ]] || continue
+    current_lines="$(awk 'END { print NR + 0 }' "${absolute_path}")"
+    baseline_count="${baseline_lines["${rust_file}"]:-0}"
+    baseline_has_file=false
+    if [[ -n "${baseline_lines["${rust_file}"]+present}" ]]; then
+        baseline_has_file=true
+    fi
+    checked=$((checked + 1))
+
+    if [[ "${current_lines}" -le "${MAX_LINES}" ]]; then
+        continue
+    fi
+    if [[ "${baseline_has_file}" == false ]]; then
+        printf '%s: new oversized file has %d lines (limit %d)\n' \
+            "${rust_file}" "${current_lines}" "${MAX_LINES}" >&2
+        violations=$((violations + 1))
+    elif [[ "${baseline_count}" -le "${MAX_LINES}" ]]; then
+        printf '%s: grew from %d to %d lines and now exceeds limit %d\n' \
+            "${rust_file}" "${baseline_count}" "${current_lines}" "${MAX_LINES}" >&2
+        violations=$((violations + 1))
+    elif [[ "${current_lines}" -gt "${baseline_count}" ]]; then
+        printf '%s: oversized file grew from %d to %d lines (limit %d)\n' \
+            "${rust_file}" "${baseline_count}" "${current_lines}" "${MAX_LINES}" >&2
+        violations=$((violations + 1))
+    fi
+done < <(
+    git -C "${SCAN_ROOT}" ls-files --cached --others --exclude-standard -z -- '*.rs'
+)
+
+if [[ "${violations}" -ne 0 ]]; then
+    printf 'Rust file size ratchet failed against %s: %d of %d files regressed\n' \
+        "${BASELINE_REF}" "${violations}" "${checked}" >&2
+    exit 1
+fi
+
+printf '[quality] Rust file size ratchet passed: %d files against %s, limit %d lines\n' \
+    "${checked}" "${BASELINE_REF}" "${MAX_LINES}"

--- a/scripts/quality-gate-self-test.sh
+++ b/scripts/quality-gate-self-test.sh
@@ -21,6 +21,7 @@ ROOT_LOCKFILE="${REPOSITORY_ROOT}/Cargo.lock"
 RUNTIME_PROPERTY_LOCKFILE="${REPOSITORY_ROOT}/plugins/random_property/Cargo.lock"
 QUALITY_GATE="${SCRIPT_DIR}/quality-gate.sh"
 RUST_FILE_SIZE_GATE="${SCRIPT_DIR}/check-rust-file-size.sh"
+RUST_FILE_SIZE_RATCHET="${SCRIPT_DIR}/check-rust-file-size-ratchet.sh"
 
 if [[ ! -f "${ROOT_LOCKFILE}" ]]; then
     echo "root Cargo.lock is required for reproducible quality gates" >&2
@@ -82,6 +83,7 @@ require_gate_command 'cargo test --workspace --all-targets --all-features --lock
 require_gate_command 'RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked'
 require_gate_command 'RUSTDOCFLAGS="-D warnings" cargo test --workspace --all-features --doc --locked'
 require_gate_command '"${SCRIPT_DIR}/quality-gate-self-test.sh"'
+require_gate_command '"${SCRIPT_DIR}/check-rust-file-size-ratchet.sh"'
 require_gate_command '-u QUALITY_ADVISORY_EXCEPTION_FILE \'
 require_gate_command '-u QUALITY_AUDIT_VALIDATE_ONLY \'
 require_gate_command '-u QUALITY_TOOL_ROOT \'
@@ -124,6 +126,97 @@ if ! grep -Fq 'production-limit.rs: 1001 lines (limit 1000)' \
     cat "${TEST_LOG_DIR}/rust-file-size-default.log" >&2
     exit 1
 fi
+
+RUST_RATCHET_FIXTURE="${TEST_LOG_DIR}/rust-file-size-ratchet"
+mkdir -p "${RUST_RATCHET_FIXTURE}"
+git -C "${RUST_RATCHET_FIXTURE}" init -q
+git -C "${RUST_RATCHET_FIXTURE}" config user.email quality@example.invalid
+git -C "${RUST_RATCHET_FIXTURE}" config user.name 'Quality Gate'
+awk 'BEGIN { for (line = 1; line <= 4; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/existing-oversized.rs"
+awk 'BEGIN { for (line = 1; line <= 3; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/boundary.rs"
+: > "${RUST_RATCHET_FIXTURE}/empty.rs"
+git -C "${RUST_RATCHET_FIXTURE}" add -- '*.rs'
+git -C "${RUST_RATCHET_FIXTURE}" commit -qm baseline
+RUST_RATCHET_BASELINE="$(git -C "${RUST_RATCHET_FIXTURE}" rev-parse HEAD)"
+
+# An unavailable implicit integration base must fail closed rather than
+# silently comparing the branch with itself.
+if "${RUST_FILE_SIZE_RATCHET}" --root "${RUST_RATCHET_FIXTURE}" \
+    > "${TEST_LOG_DIR}/rust-file-size-ratchet-no-baseline.log" 2>&1; then
+    echo "Rust file size ratchet unexpectedly passed without a baseline" >&2
+    exit 1
+fi
+if ! grep -Fq 'Rust file size baseline is required' \
+    "${TEST_LOG_DIR}/rust-file-size-ratchet-no-baseline.log"; then
+    echo "missing Rust file size baseline failed for the wrong reason" >&2
+    cat "${TEST_LOG_DIR}/rust-file-size-ratchet-no-baseline.log" >&2
+    exit 1
+fi
+
+# Comparing with an unrelated or newer commit can hide branch regressions, so
+# only an actual ancestor may serve as the integration baseline.
+git -C "${RUST_RATCHET_FIXTURE}" checkout -qb unrelated
+echo '// unrelated history' > "${RUST_RATCHET_FIXTURE}/unrelated.rs"
+git -C "${RUST_RATCHET_FIXTURE}" add -- unrelated.rs
+git -C "${RUST_RATCHET_FIXTURE}" commit -qm unrelated
+RUST_RATCHET_UNRELATED="$(git -C "${RUST_RATCHET_FIXTURE}" rev-parse HEAD)"
+git -C "${RUST_RATCHET_FIXTURE}" checkout -q --detach "${RUST_RATCHET_BASELINE}"
+if "${RUST_FILE_SIZE_RATCHET}" --root "${RUST_RATCHET_FIXTURE}" \
+    --baseline-ref "${RUST_RATCHET_UNRELATED}" --max-lines 3 \
+    > "${TEST_LOG_DIR}/rust-file-size-ratchet-unrelated.log" 2>&1; then
+    echo "Rust file size ratchet unexpectedly accepted a non-ancestor baseline" >&2
+    exit 1
+fi
+if ! grep -Fq 'Rust file size baseline must be an ancestor of HEAD' \
+    "${TEST_LOG_DIR}/rust-file-size-ratchet-unrelated.log"; then
+    echo "non-ancestor Rust file size baseline failed for the wrong reason" >&2
+    cat "${TEST_LOG_DIR}/rust-file-size-ratchet-unrelated.log" >&2
+    exit 1
+fi
+
+# Existing debt may shrink or remain unchanged.
+awk 'BEGIN { for (line = 1; line <= 3; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/existing-oversized.rs"
+"${RUST_FILE_SIZE_RATCHET}" --root "${RUST_RATCHET_FIXTURE}" \
+    --baseline-ref "${RUST_RATCHET_BASELINE}" --max-lines 3 \
+    > "${TEST_LOG_DIR}/rust-file-size-ratchet-pass.log"
+
+expect_ratchet_failure() {
+    local expected="$1"
+    local log_file="${TEST_LOG_DIR}/rust-file-size-ratchet-fail.log"
+    if "${RUST_FILE_SIZE_RATCHET}" --root "${RUST_RATCHET_FIXTURE}" \
+        --baseline-ref "${RUST_RATCHET_BASELINE}" --max-lines 3 \
+        >"${log_file}" 2>&1; then
+        echo "Rust file size regression unexpectedly passed" >&2
+        exit 1
+    fi
+    if ! grep -Fq "${expected}" "${log_file}"; then
+        echo "Rust file size ratchet failed for the wrong reason" >&2
+        cat "${log_file}" >&2
+        exit 1
+    fi
+}
+
+awk 'BEGIN { for (line = 1; line <= 5; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/existing-oversized.rs"
+expect_ratchet_failure 'existing-oversized.rs: oversized file grew from 4 to 5 lines'
+git -C "${RUST_RATCHET_FIXTURE}" checkout -q -- existing-oversized.rs
+
+awk 'BEGIN { for (line = 1; line <= 4; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/boundary.rs"
+expect_ratchet_failure 'boundary.rs: grew from 3 to 4 lines and now exceeds limit 3'
+git -C "${RUST_RATCHET_FIXTURE}" checkout -q -- boundary.rs
+
+awk 'BEGIN { for (line = 1; line <= 4; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/empty.rs"
+expect_ratchet_failure 'empty.rs: grew from 0 to 4 lines and now exceeds limit 3'
+git -C "${RUST_RATCHET_FIXTURE}" checkout -q -- empty.rs
+
+awk 'BEGIN { for (line = 1; line <= 4; line += 1) print "// line" }' \
+    > "${RUST_RATCHET_FIXTURE}/new.rs"
+expect_ratchet_failure 'new.rs: new oversized file has 4 lines (limit 3)'
 
 # This also catches a stale lockfile after workspace manifests change.
 cargo metadata \

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -14,6 +14,9 @@ echo "[quality] shell syntax and policy self-test"
 bash -n "${SCRIPT_DIR}"/*.sh
 "${SCRIPT_DIR}/quality-gate-self-test.sh"
 
+echo "[quality] Rust file size ratchet"
+"${SCRIPT_DIR}/check-rust-file-size-ratchet.sh"
+
 echo "[quality] rustfmt"
 cargo fmt --all -- --check
 cargo fmt --manifest-path "${RUNTIME_PROPERTY_PLUGIN_MANIFEST}" -- --check


### PR DESCRIPTION
### Motivation

- Prevent unbounded growth of Rust source files by detecting regressions versus an integration baseline and enforce a per-file line limit.
- Extend the existing quality gate so file-size regressions are caught as part of CI and local self-tests.

### Description

- Add `scripts/check-rust-file-size-ratchet.sh`, a Git-aware ratchet that compares `.rs` file line counts against a baseline commit and enforces a `--max-lines` limit (default 1000), with options `--root` and `--baseline-ref` and validation that the baseline is an ancestor of `HEAD`.
- The ratchet reports new oversized files, files that grew past the limit, and oversized files that increased in size, and it fails non-zero on regressions or misconfiguration (missing baseline, non-ancestor baseline, non-git worktree, invalid `--max-lines`).
- Integrate the ratchet into the top-level `scripts/quality-gate.sh` so it runs during the quality pipeline.
- Extend `scripts/quality-gate-self-test.sh` to exercise the ratchet with fixture repositories and assertions for missing baseline, non-ancestor baseline, shrinking/unchanged debt, and multiple regression scenarios.

### Testing

- Performed static shell checks with `bash -n "${SCRIPT_DIR}"/*.sh` as part of the self-test and ran the self-test script `scripts/quality-gate-self-test.sh` which includes the new ratchet checks.
- The self-test creates Git fixtures and asserts the ratchet rejects missing baseline and non-ancestor baselines and correctly accepts or rejects the various growth/shrink/new-file cases described in the tests.
- All added automated self-tests for the ratchet and the existing Rust file-size gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dc4e7c084832f806579429878f2d4)

## Summary by Sourcery

Introduce a Git-based Rust file size ratchet and wire it into the quality gate pipeline to block regressions in per-file line counts.

New Features:
- Add a Rust file size ratchet script that compares .rs file line counts against a baseline commit and enforces a configurable per-file line limit.

Enhancements:
- Integrate the Rust file size ratchet into the main quality-gate script so it runs as part of the standard quality checks.

Tests:
- Extend the quality gate self-test to create Git fixtures and validate the ratchet behavior for missing or invalid baselines and multiple file growth and new-file regression scenarios.